### PR TITLE
ci: rename "env" var to "build-env" to avoid rewrite of system "env" variable and not lost custom variables so run with some defaults (#407)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,8 +3,7 @@ e**/.classpath
 **/.settings
 **/.toolstarget
 **/.vs
-**/.vscode
-**/.husky
+**/.vscodee
 **/*.*proj.user
 **/*.dbmdl
 **/*.jfm


### PR DESCRIPTION
* ci: rename env var to build-env
* ci: use feature branch instead of master
* Revert \'ci: use feature branch instead of master\'
* docs: rename env to build-env in comment